### PR TITLE
Provide CMakeFiles.txt files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+project(wide-integer)
+
+cmake_minimum_required(VERSION 3.16.3)
+
+add_subdirectory("examples")
+
+include(CTest)
+add_subdirectory("test")
+
+add_library(wide-integer INTERFACE)
+target_compile_features(wide-integer INTERFACE cxx_std_11)
+
+target_include_directories(
+    wide-integer INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ Continuous integration runs on push using GitHub Actions.
 Various compilers, operating systems, and C++ standards
 ranging from C++11, 14, 17, 20 are included in CI.
 
+You can build and run tests from an empty directory using CMake:
+
+```sh
+cmake /path/to/wide-integer
+cmake --build .
+ctest --verbose
+```
+
 ### Build Status
 [![Build Status](https://github.com/ckormanyos/wide-integer/actions/workflows/wide_integer.yml/badge.svg)](https://github.com/ckormanyos/wide-integer/actions)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_library(examples
+  example001_mul_div.cpp
+  example001a_div_mod.cpp
+  example002_shl_shr.cpp
+  example003_sqrt.cpp
+  example003a_cbrt.cpp
+  example004_rootk_pow.cpp
+  example005_powm.cpp
+  example006_gcd.cpp
+  example007_random_generator.cpp
+  example008_miller_rabin_prime.cpp
+  example008a_miller_rabin_prime.cpp
+  example009_timed_mul.cpp
+  example009a_timed_mul_4_by_4.cpp
+  example010_uint48_t.cpp
+  example011_uint24_t.cpp)
+target_compile_features(examples PRIVATE cxx_std_11)
+target_include_directories(examples PRIVATE ${PROJECT_SOURCE_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,15 @@
+enable_testing()
+find_package(Threads)
+find_package(Boost 1.55.0)
+add_executable(test_uintwide_t
+  test_uintwide_t_boost_backend.cpp
+  test_uintwide_t_edge_cases.cpp
+  test_uintwide_t_examples.cpp
+  test_uintwide_t_n_base.cpp
+  test_uintwide_t_n_binary_ops_base.cpp
+  test_uintwide_t_spot_values.cpp
+  test.cpp)
+target_compile_features(test_uintwide_t PRIVATE cxx_std_11)
+target_include_directories(test_uintwide_t PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(test_uintwide_t examples ${CMAKE_THREAD_LIBS_INIT})
+add_test(test test_uintwide_t)


### PR DESCRIPTION
I threw together CMake support while exploring the code to help me build it on Linux. I figured you might find it useful for simplifying your scripts.

If you have any suggestions around compiler-specific flags etc. you'd like to see, LMK. I'd generally recommend keeping the CMakeLists.txt files toolchain-agnostic for better portability and future-proofing so I recommend alternative approaches to adding compile-specific flags, i.e. [CXX](https://cmake.org/cmake/help/latest/envvar/CXX.html) and [CXXFLAGS](https://cmake.org/cmake/help/latest/envvar/CXXFLAGS.html) or toolchain files.