### PR TITLE
CMake fixes

### DIFF
--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -1130,6 +1130,6 @@ jobs:
           mkdir build
           cd build
           ls $GITHUB_WORKSPACE/../boost-root
-          BOOST_ROOT=$GITHUB_WORKSPACE/../boost-root cmake -DCMAKE_CXX_STANDARD_REQUIRED=20 -DCMAKE_CXX_STANDARD=11 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" ..
+          BOOST_ROOT=$GITHUB_WORKSPACE/../boost-root cmake -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" ..
           cmake --build . -- -j $(nproc)
           ctest --verbose --output-on-failure -j $(nproc)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,4 +17,5 @@ add_library(examples
   example010_uint48_t.cpp
   example011_uint24_t.cpp)
 target_compile_features(examples PRIVATE cxx_std_11)
-target_include_directories(examples PRIVATE ${PROJECT_SOURCE_DIR} PUBLIC ${Boost_INCLUDE_DIRS})
+target_include_directories(examples PRIVATE ${PROJECT_SOURCE_DIR})
+target_include_directories(examples SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
A few minor fixes to CMake builds:

- suppress warnings in Boost
- remove ineffective CMake flag
- select C++20 in CMake Actions job