### PR TITLE
CMake dependency improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,10 @@ add_subdirectory("examples")
 include(CTest)
 add_subdirectory("test")
 
-add_library(wide-integer INTERFACE)
-target_compile_features(wide-integer INTERFACE cxx_std_11)
+add_library(WideInteger INTERFACE)
+target_compile_features(WideInteger INTERFACE cxx_std_11)
 
 target_include_directories(
-  wide-integer INTERFACE
+  WideInteger INTERFACE
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,6 @@ add_library(wide-integer INTERFACE)
 target_compile_features(wide-integer INTERFACE cxx_std_11)
 
 target_include_directories(
-    wide-integer INTERFACE
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include>)
+  wide-integer INTERFACE
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,13 @@ project(wide-integer)
 
 cmake_minimum_required(VERSION 3.16.3)
 
-add_subdirectory("examples")
+find_package(Boost)
+if (Boost_FOUND)
+  include(CTest)
 
-include(CTest)
-add_subdirectory("test")
+  add_subdirectory("examples")
+  add_subdirectory("test")
+endif()
 
 add_library(WideInteger INTERFACE)
 target_compile_features(WideInteger INTERFACE cxx_std_11)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,3 @@
-find_package(Boost REQUIRED)
 add_library(Examples
   example000_numeric_limits.cpp
   example000a_builtin_convert.cpp

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(Boost REQUIRED)
-add_library(examples
+add_library(Examples
   example000_numeric_limits.cpp
   example000a_builtin_convert.cpp
   example001_mul_div.cpp
@@ -18,6 +18,6 @@ add_library(examples
   example009b_timed_mul_8_by_8.cpp
   example010_uint48_t.cpp
   example011_uint24_t.cpp)
-target_compile_features(examples PRIVATE cxx_std_11)
-target_include_directories(examples PRIVATE ${PROJECT_SOURCE_DIR})
-target_include_directories(examples SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
+target_compile_features(Examples PRIVATE cxx_std_11)
+target_include_directories(Examples PRIVATE ${PROJECT_SOURCE_DIR})
+target_include_directories(Examples SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,5 +11,5 @@ add_executable(test_uintwide_t
   test.cpp)
 target_compile_features(test_uintwide_t PRIVATE cxx_std_11)
 target_include_directories(test_uintwide_t PRIVATE ${PROJECT_SOURCE_DIR})
-target_link_libraries(test_uintwide_t examples ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(test_uintwide_t Examples ${CMAKE_THREAD_LIBS_INIT})
 add_test(test test_uintwide_t)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,15 +1,17 @@
 enable_testing()
 find_package(Threads)
-add_executable(test_uintwide_t
-  test_uintwide_t_boost_backend.cpp
-  test_uintwide_t_edge_cases.cpp
-  test_uintwide_t_examples.cpp
-  test_uintwide_t_float_convert.cpp
-  test_uintwide_t_n_base.cpp
-  test_uintwide_t_n_binary_ops_base.cpp
-  test_uintwide_t_spot_values.cpp
-  test.cpp)
-target_compile_features(test_uintwide_t PRIVATE cxx_std_11)
-target_include_directories(test_uintwide_t PRIVATE ${PROJECT_SOURCE_DIR})
-target_link_libraries(test_uintwide_t Examples ${CMAKE_THREAD_LIBS_INIT})
-add_test(test test_uintwide_t)
+if (Boost_FOUND)
+  add_executable(test_uintwide_t
+    test_uintwide_t_boost_backend.cpp
+    test_uintwide_t_edge_cases.cpp
+    test_uintwide_t_examples.cpp
+    test_uintwide_t_float_convert.cpp
+    test_uintwide_t_n_base.cpp
+    test_uintwide_t_n_binary_ops_base.cpp
+    test_uintwide_t_spot_values.cpp
+    test.cpp)
+  target_compile_features(test_uintwide_t PRIVATE cxx_std_11)
+  target_include_directories(test_uintwide_t PRIVATE ${PROJECT_SOURCE_DIR})
+  target_link_libraries(test_uintwide_t Examples ${CMAKE_THREAD_LIBS_INIT})
+  add_test(test test_uintwide_t)
+endif()


### PR DESCRIPTION
# Make Boost a conditional dependency in CMake

Previously, anything that pulls in wide-integer using CMake would also need to have much of Boost on hand. This change quietly bypasses all tests if Boost is not found.

This seems to be a fairly typical way of dealing with non-required dependencies in CMake, even though it can be hard to find errors when they're not 'hard' errors. However, Boost isn't a dependency of the library itself and this stops it being necessary.

# ~~`install` CMake commands~~

~~These tell CMake how to export the artifacts from the build process. It's disappointingly clunky in my opinion: you say exactly what bits that fall out of the tool chain need to be copied to the user's area. But it works!~~