### PR TITLE
Reduce boost cloning

### DIFF
--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -36,6 +36,7 @@ jobs:
           git submodule update --init libs/exception
           git submodule update --init libs/functional
           git submodule update --init libs/integer
+          git submodule update --init libs/io
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
@@ -92,6 +93,7 @@ jobs:
           git submodule update --init libs/exception
           git submodule update --init libs/functional
           git submodule update --init libs/integer
+          git submodule update --init libs/io
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
@@ -150,6 +152,7 @@ jobs:
           git submodule update --init libs/exception
           git submodule update --init libs/functional
           git submodule update --init libs/integer
+          git submodule update --init libs/io
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
@@ -208,6 +211,7 @@ jobs:
           git submodule update --init libs/exception
           git submodule update --init libs/functional
           git submodule update --init libs/integer
+          git submodule update --init libs/io
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
@@ -264,6 +268,7 @@ jobs:
           git submodule update --init libs/exception
           git submodule update --init libs/functional
           git submodule update --init libs/integer
+          git submodule update --init libs/io
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
@@ -320,6 +325,7 @@ jobs:
           git submodule update --init libs/exception
           git submodule update --init libs/functional
           git submodule update --init libs/integer
+          git submodule update --init libs/io
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
@@ -376,6 +382,7 @@ jobs:
           git submodule update --init libs/exception
           git submodule update --init libs/functional
           git submodule update --init libs/integer
+          git submodule update --init libs/io
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
@@ -432,6 +439,7 @@ jobs:
           git submodule update --init libs/exception
           git submodule update --init libs/functional
           git submodule update --init libs/integer
+          git submodule update --init libs/io
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
@@ -488,6 +496,7 @@ jobs:
           git submodule update --init libs/exception
           git submodule update --init libs/functional
           git submodule update --init libs/integer
+          git submodule update --init libs/io
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
@@ -536,6 +545,7 @@ jobs:
           git submodule update --init libs/exception
           git submodule update --init libs/functional
           git submodule update --init libs/integer
+          git submodule update --init libs/io
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
@@ -590,6 +600,7 @@ jobs:
           git submodule update --init libs/exception
           git submodule update --init libs/functional
           git submodule update --init libs/integer
+          git submodule update --init libs/io
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math

--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -27,6 +27,7 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/concept_check
           git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
@@ -79,6 +80,7 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/concept_check
           git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
@@ -133,6 +135,7 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/concept_check
           git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
@@ -187,6 +190,7 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/concept_check
           git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
@@ -239,6 +243,7 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/concept_check
           git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
@@ -291,6 +296,7 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/concept_check
           git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
@@ -343,6 +349,7 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/concept_check
           git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
@@ -395,6 +402,7 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/concept_check
           git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
@@ -447,6 +455,7 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/concept_check
           git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
@@ -491,6 +500,7 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/concept_check
           git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
@@ -541,6 +551,7 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/concept_check
           git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core

--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -49,6 +49,7 @@ jobs:
           git submodule update --init libs/static_assert
           git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
+          git submodule update --init libs/utility
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native
@@ -102,6 +103,7 @@ jobs:
           git submodule update --init libs/static_assert
           git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
+          git submodule update --init libs/utility
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-limb_type_uint64_t
@@ -157,6 +159,7 @@ jobs:
           git submodule update --init libs/static_assert
           git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
+          git submodule update --init libs/utility
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-x86
@@ -212,6 +215,7 @@ jobs:
           git submodule update --init libs/static_assert
           git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
+          git submodule update --init libs/utility
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-10
@@ -265,6 +269,7 @@ jobs:
           git submodule update --init libs/static_assert
           git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
+          git submodule update --init libs/utility
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-asan
@@ -318,6 +323,7 @@ jobs:
           git submodule update --init libs/static_assert
           git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
+          git submodule update --init libs/utility
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-ubsan
@@ -371,6 +377,7 @@ jobs:
           git submodule update --init libs/static_assert
           git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
+          git submodule update --init libs/utility
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-ubsan-limb_type_uint64_t
@@ -424,6 +431,7 @@ jobs:
           git submodule update --init libs/static_assert
           git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
+          git submodule update --init libs/utility
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-tsan
@@ -477,6 +485,7 @@ jobs:
           git submodule update --init libs/static_assert
           git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
+          git submodule update --init libs/utility
           ./bootstrap.sh
           ./b2 headers
       - name: apple-gcc-clang-native
@@ -522,6 +531,7 @@ jobs:
           git submodule update --init libs/static_assert
           git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
+          git submodule update --init libs/utility
           ./bootstrap.bat
           ./b2 headers
       - uses: actions/checkout@v1
@@ -573,6 +583,7 @@ jobs:
           git submodule update --init libs/static_assert
           git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
+          git submodule update --init libs/utility
           ./bootstrap.bat
           ./b2 headers
       - name: mingw-winhost-x64

--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -24,77 +24,11 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
-          git submodule update --init libs/algorithm
-          git submodule update --init libs/align
-          git submodule update --init libs/any
-          git submodule update --init libs/array
           git submodule update --init libs/assert
-          git submodule update --init libs/atomic
-          git submodule update --init libs/bind
-          git submodule update --init libs/chrono
-          git submodule update --init libs/circular_buffer
-          git submodule update --init libs/compute
-          git submodule update --init libs/concept_check
           git submodule update --init libs/config
-          git submodule update --init libs/container
-          git submodule update --init libs/container_hash
-          git submodule update --init libs/conversion
           git submodule update --init libs/core
-          git submodule update --init libs/date_time
-          git submodule update --init libs/detail
-          git submodule update --init libs/dynamic_bitset
-          git submodule update --init libs/endian
           git submodule update --init libs/exception
-          git submodule update --init libs/foreach
-          git submodule update --init libs/format
-          git submodule update --init libs/function
-          git submodule update --init libs/function_types
-          git submodule update --init libs/fusion
-          git submodule update --init libs/hana
-          git submodule update --init libs/headers
-          git submodule update --init libs/integer
-          git submodule update --init libs/intrusive
-          git submodule update --init libs/io
-          git submodule update --init libs/iterator
-          git submodule update --init libs/lambda
-          git submodule update --init libs/lexical_cast
-          git submodule update --init libs/logic
-          git submodule update --init libs/math
-          git submodule update --init libs/move
-          git submodule update --init libs/mp11
-          git submodule update --init libs/mpl
-          git submodule update --init libs/multi_index
           git submodule update --init libs/multiprecision
-          git submodule update --init libs/numeric/conversion
-          git submodule update --init libs/numeric/interval
-          git submodule update --init libs/optional
-          git submodule update --init libs/phoenix
-          git submodule update --init libs/pool
-          git submodule update --init libs/predef
-          git submodule update --init libs/preprocessor
-          git submodule update --init libs/property_tree
-          git submodule update --init libs/proto
-          git submodule update --init libs/random
-          git submodule update --init libs/range
-          git submodule update --init libs/ratio
-          git submodule update --init libs/rational
-          git submodule update --init libs/regex
-          git submodule update --init libs/serialization
-          git submodule update --init libs/smart_ptr
-          git submodule update --init libs/spirit
-          git submodule update --init libs/static_assert
-          git submodule update --init libs/system
-          git submodule update --init libs/thread
-          git submodule update --init libs/throw_exception
-          git submodule update --init libs/tokenizer
-          git submodule update --init libs/tti
-          git submodule update --init libs/tuple
-          git submodule update --init libs/type_index
-          git submodule update --init libs/type_traits
-          git submodule update --init libs/typeof
-          git submodule update --init libs/unordered
-          git submodule update --init libs/utility
-          git submodule update --init libs/variant
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native
@@ -125,77 +59,11 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
-          git submodule update --init libs/algorithm
-          git submodule update --init libs/align
-          git submodule update --init libs/any
-          git submodule update --init libs/array
           git submodule update --init libs/assert
-          git submodule update --init libs/atomic
-          git submodule update --init libs/bind
-          git submodule update --init libs/chrono
-          git submodule update --init libs/circular_buffer
-          git submodule update --init libs/compute
-          git submodule update --init libs/concept_check
           git submodule update --init libs/config
-          git submodule update --init libs/container
-          git submodule update --init libs/container_hash
-          git submodule update --init libs/conversion
           git submodule update --init libs/core
-          git submodule update --init libs/date_time
-          git submodule update --init libs/detail
-          git submodule update --init libs/dynamic_bitset
-          git submodule update --init libs/endian
           git submodule update --init libs/exception
-          git submodule update --init libs/foreach
-          git submodule update --init libs/format
-          git submodule update --init libs/function
-          git submodule update --init libs/function_types
-          git submodule update --init libs/fusion
-          git submodule update --init libs/hana
-          git submodule update --init libs/headers
-          git submodule update --init libs/integer
-          git submodule update --init libs/intrusive
-          git submodule update --init libs/io
-          git submodule update --init libs/iterator
-          git submodule update --init libs/lambda
-          git submodule update --init libs/lexical_cast
-          git submodule update --init libs/logic
-          git submodule update --init libs/math
-          git submodule update --init libs/move
-          git submodule update --init libs/mp11
-          git submodule update --init libs/mpl
-          git submodule update --init libs/multi_index
           git submodule update --init libs/multiprecision
-          git submodule update --init libs/numeric/conversion
-          git submodule update --init libs/numeric/interval
-          git submodule update --init libs/optional
-          git submodule update --init libs/phoenix
-          git submodule update --init libs/pool
-          git submodule update --init libs/predef
-          git submodule update --init libs/preprocessor
-          git submodule update --init libs/property_tree
-          git submodule update --init libs/proto
-          git submodule update --init libs/random
-          git submodule update --init libs/range
-          git submodule update --init libs/ratio
-          git submodule update --init libs/rational
-          git submodule update --init libs/regex
-          git submodule update --init libs/serialization
-          git submodule update --init libs/smart_ptr
-          git submodule update --init libs/spirit
-          git submodule update --init libs/static_assert
-          git submodule update --init libs/system
-          git submodule update --init libs/thread
-          git submodule update --init libs/throw_exception
-          git submodule update --init libs/tokenizer
-          git submodule update --init libs/tti
-          git submodule update --init libs/tuple
-          git submodule update --init libs/type_index
-          git submodule update --init libs/type_traits
-          git submodule update --init libs/typeof
-          git submodule update --init libs/unordered
-          git submodule update --init libs/utility
-          git submodule update --init libs/variant
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-limb_type_uint64_t
@@ -228,77 +96,11 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
-          git submodule update --init libs/algorithm
-          git submodule update --init libs/align
-          git submodule update --init libs/any
-          git submodule update --init libs/array
           git submodule update --init libs/assert
-          git submodule update --init libs/atomic
-          git submodule update --init libs/bind
-          git submodule update --init libs/chrono
-          git submodule update --init libs/circular_buffer
-          git submodule update --init libs/compute
-          git submodule update --init libs/concept_check
           git submodule update --init libs/config
-          git submodule update --init libs/container
-          git submodule update --init libs/container_hash
-          git submodule update --init libs/conversion
           git submodule update --init libs/core
-          git submodule update --init libs/date_time
-          git submodule update --init libs/detail
-          git submodule update --init libs/dynamic_bitset
-          git submodule update --init libs/endian
           git submodule update --init libs/exception
-          git submodule update --init libs/foreach
-          git submodule update --init libs/format
-          git submodule update --init libs/function
-          git submodule update --init libs/function_types
-          git submodule update --init libs/fusion
-          git submodule update --init libs/hana
-          git submodule update --init libs/headers
-          git submodule update --init libs/integer
-          git submodule update --init libs/intrusive
-          git submodule update --init libs/io
-          git submodule update --init libs/iterator
-          git submodule update --init libs/lambda
-          git submodule update --init libs/lexical_cast
-          git submodule update --init libs/logic
-          git submodule update --init libs/math
-          git submodule update --init libs/move
-          git submodule update --init libs/mp11
-          git submodule update --init libs/mpl
-          git submodule update --init libs/multi_index
           git submodule update --init libs/multiprecision
-          git submodule update --init libs/numeric/conversion
-          git submodule update --init libs/numeric/interval
-          git submodule update --init libs/optional
-          git submodule update --init libs/phoenix
-          git submodule update --init libs/pool
-          git submodule update --init libs/predef
-          git submodule update --init libs/preprocessor
-          git submodule update --init libs/property_tree
-          git submodule update --init libs/proto
-          git submodule update --init libs/random
-          git submodule update --init libs/range
-          git submodule update --init libs/ratio
-          git submodule update --init libs/rational
-          git submodule update --init libs/regex
-          git submodule update --init libs/serialization
-          git submodule update --init libs/smart_ptr
-          git submodule update --init libs/spirit
-          git submodule update --init libs/static_assert
-          git submodule update --init libs/system
-          git submodule update --init libs/thread
-          git submodule update --init libs/throw_exception
-          git submodule update --init libs/tokenizer
-          git submodule update --init libs/tti
-          git submodule update --init libs/tuple
-          git submodule update --init libs/type_index
-          git submodule update --init libs/type_traits
-          git submodule update --init libs/typeof
-          git submodule update --init libs/unordered
-          git submodule update --init libs/utility
-          git submodule update --init libs/variant
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-x86
@@ -331,77 +133,11 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
-          git submodule update --init libs/algorithm
-          git submodule update --init libs/align
-          git submodule update --init libs/any
-          git submodule update --init libs/array
           git submodule update --init libs/assert
-          git submodule update --init libs/atomic
-          git submodule update --init libs/bind
-          git submodule update --init libs/chrono
-          git submodule update --init libs/circular_buffer
-          git submodule update --init libs/compute
-          git submodule update --init libs/concept_check
           git submodule update --init libs/config
-          git submodule update --init libs/container
-          git submodule update --init libs/container_hash
-          git submodule update --init libs/conversion
           git submodule update --init libs/core
-          git submodule update --init libs/date_time
-          git submodule update --init libs/detail
-          git submodule update --init libs/dynamic_bitset
-          git submodule update --init libs/endian
           git submodule update --init libs/exception
-          git submodule update --init libs/foreach
-          git submodule update --init libs/format
-          git submodule update --init libs/function
-          git submodule update --init libs/function_types
-          git submodule update --init libs/fusion
-          git submodule update --init libs/hana
-          git submodule update --init libs/headers
-          git submodule update --init libs/integer
-          git submodule update --init libs/intrusive
-          git submodule update --init libs/io
-          git submodule update --init libs/iterator
-          git submodule update --init libs/lambda
-          git submodule update --init libs/lexical_cast
-          git submodule update --init libs/logic
-          git submodule update --init libs/math
-          git submodule update --init libs/move
-          git submodule update --init libs/mp11
-          git submodule update --init libs/mpl
-          git submodule update --init libs/multi_index
           git submodule update --init libs/multiprecision
-          git submodule update --init libs/numeric/conversion
-          git submodule update --init libs/numeric/interval
-          git submodule update --init libs/optional
-          git submodule update --init libs/phoenix
-          git submodule update --init libs/pool
-          git submodule update --init libs/predef
-          git submodule update --init libs/preprocessor
-          git submodule update --init libs/property_tree
-          git submodule update --init libs/proto
-          git submodule update --init libs/random
-          git submodule update --init libs/range
-          git submodule update --init libs/ratio
-          git submodule update --init libs/rational
-          git submodule update --init libs/regex
-          git submodule update --init libs/serialization
-          git submodule update --init libs/smart_ptr
-          git submodule update --init libs/spirit
-          git submodule update --init libs/static_assert
-          git submodule update --init libs/system
-          git submodule update --init libs/thread
-          git submodule update --init libs/throw_exception
-          git submodule update --init libs/tokenizer
-          git submodule update --init libs/tti
-          git submodule update --init libs/tuple
-          git submodule update --init libs/type_index
-          git submodule update --init libs/type_traits
-          git submodule update --init libs/typeof
-          git submodule update --init libs/unordered
-          git submodule update --init libs/utility
-          git submodule update --init libs/variant
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-10
@@ -432,77 +168,11 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
-          git submodule update --init libs/algorithm
-          git submodule update --init libs/align
-          git submodule update --init libs/any
-          git submodule update --init libs/array
           git submodule update --init libs/assert
-          git submodule update --init libs/atomic
-          git submodule update --init libs/bind
-          git submodule update --init libs/chrono
-          git submodule update --init libs/circular_buffer
-          git submodule update --init libs/compute
-          git submodule update --init libs/concept_check
           git submodule update --init libs/config
-          git submodule update --init libs/container
-          git submodule update --init libs/container_hash
-          git submodule update --init libs/conversion
           git submodule update --init libs/core
-          git submodule update --init libs/date_time
-          git submodule update --init libs/detail
-          git submodule update --init libs/dynamic_bitset
-          git submodule update --init libs/endian
           git submodule update --init libs/exception
-          git submodule update --init libs/foreach
-          git submodule update --init libs/format
-          git submodule update --init libs/function
-          git submodule update --init libs/function_types
-          git submodule update --init libs/fusion
-          git submodule update --init libs/hana
-          git submodule update --init libs/headers
-          git submodule update --init libs/integer
-          git submodule update --init libs/intrusive
-          git submodule update --init libs/io
-          git submodule update --init libs/iterator
-          git submodule update --init libs/lambda
-          git submodule update --init libs/lexical_cast
-          git submodule update --init libs/logic
-          git submodule update --init libs/math
-          git submodule update --init libs/move
-          git submodule update --init libs/mp11
-          git submodule update --init libs/mpl
-          git submodule update --init libs/multi_index
           git submodule update --init libs/multiprecision
-          git submodule update --init libs/numeric/conversion
-          git submodule update --init libs/numeric/interval
-          git submodule update --init libs/optional
-          git submodule update --init libs/phoenix
-          git submodule update --init libs/pool
-          git submodule update --init libs/predef
-          git submodule update --init libs/preprocessor
-          git submodule update --init libs/property_tree
-          git submodule update --init libs/proto
-          git submodule update --init libs/random
-          git submodule update --init libs/range
-          git submodule update --init libs/ratio
-          git submodule update --init libs/rational
-          git submodule update --init libs/regex
-          git submodule update --init libs/serialization
-          git submodule update --init libs/smart_ptr
-          git submodule update --init libs/spirit
-          git submodule update --init libs/static_assert
-          git submodule update --init libs/system
-          git submodule update --init libs/thread
-          git submodule update --init libs/throw_exception
-          git submodule update --init libs/tokenizer
-          git submodule update --init libs/tti
-          git submodule update --init libs/tuple
-          git submodule update --init libs/type_index
-          git submodule update --init libs/type_traits
-          git submodule update --init libs/typeof
-          git submodule update --init libs/unordered
-          git submodule update --init libs/utility
-          git submodule update --init libs/variant
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-asan
@@ -533,77 +203,11 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
-          git submodule update --init libs/algorithm
-          git submodule update --init libs/align
-          git submodule update --init libs/any
-          git submodule update --init libs/array
           git submodule update --init libs/assert
-          git submodule update --init libs/atomic
-          git submodule update --init libs/bind
-          git submodule update --init libs/chrono
-          git submodule update --init libs/circular_buffer
-          git submodule update --init libs/compute
-          git submodule update --init libs/concept_check
           git submodule update --init libs/config
-          git submodule update --init libs/container
-          git submodule update --init libs/container_hash
-          git submodule update --init libs/conversion
           git submodule update --init libs/core
-          git submodule update --init libs/date_time
-          git submodule update --init libs/detail
-          git submodule update --init libs/dynamic_bitset
-          git submodule update --init libs/endian
           git submodule update --init libs/exception
-          git submodule update --init libs/foreach
-          git submodule update --init libs/format
-          git submodule update --init libs/function
-          git submodule update --init libs/function_types
-          git submodule update --init libs/fusion
-          git submodule update --init libs/hana
-          git submodule update --init libs/headers
-          git submodule update --init libs/integer
-          git submodule update --init libs/intrusive
-          git submodule update --init libs/io
-          git submodule update --init libs/iterator
-          git submodule update --init libs/lambda
-          git submodule update --init libs/lexical_cast
-          git submodule update --init libs/logic
-          git submodule update --init libs/math
-          git submodule update --init libs/move
-          git submodule update --init libs/mp11
-          git submodule update --init libs/mpl
-          git submodule update --init libs/multi_index
           git submodule update --init libs/multiprecision
-          git submodule update --init libs/numeric/conversion
-          git submodule update --init libs/numeric/interval
-          git submodule update --init libs/optional
-          git submodule update --init libs/phoenix
-          git submodule update --init libs/pool
-          git submodule update --init libs/predef
-          git submodule update --init libs/preprocessor
-          git submodule update --init libs/property_tree
-          git submodule update --init libs/proto
-          git submodule update --init libs/random
-          git submodule update --init libs/range
-          git submodule update --init libs/ratio
-          git submodule update --init libs/rational
-          git submodule update --init libs/regex
-          git submodule update --init libs/serialization
-          git submodule update --init libs/smart_ptr
-          git submodule update --init libs/spirit
-          git submodule update --init libs/static_assert
-          git submodule update --init libs/system
-          git submodule update --init libs/thread
-          git submodule update --init libs/throw_exception
-          git submodule update --init libs/tokenizer
-          git submodule update --init libs/tti
-          git submodule update --init libs/tuple
-          git submodule update --init libs/type_index
-          git submodule update --init libs/type_traits
-          git submodule update --init libs/typeof
-          git submodule update --init libs/unordered
-          git submodule update --init libs/utility
-          git submodule update --init libs/variant
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-ubsan
@@ -634,77 +238,11 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
-          git submodule update --init libs/algorithm
-          git submodule update --init libs/align
-          git submodule update --init libs/any
-          git submodule update --init libs/array
           git submodule update --init libs/assert
-          git submodule update --init libs/atomic
-          git submodule update --init libs/bind
-          git submodule update --init libs/chrono
-          git submodule update --init libs/circular_buffer
-          git submodule update --init libs/compute
-          git submodule update --init libs/concept_check
           git submodule update --init libs/config
-          git submodule update --init libs/container
-          git submodule update --init libs/container_hash
-          git submodule update --init libs/conversion
           git submodule update --init libs/core
-          git submodule update --init libs/date_time
-          git submodule update --init libs/detail
-          git submodule update --init libs/dynamic_bitset
-          git submodule update --init libs/endian
           git submodule update --init libs/exception
-          git submodule update --init libs/foreach
-          git submodule update --init libs/format
-          git submodule update --init libs/function
-          git submodule update --init libs/function_types
-          git submodule update --init libs/fusion
-          git submodule update --init libs/hana
-          git submodule update --init libs/headers
-          git submodule update --init libs/integer
-          git submodule update --init libs/intrusive
-          git submodule update --init libs/io
-          git submodule update --init libs/iterator
-          git submodule update --init libs/lambda
-          git submodule update --init libs/lexical_cast
-          git submodule update --init libs/logic
-          git submodule update --init libs/math
-          git submodule update --init libs/move
-          git submodule update --init libs/mp11
-          git submodule update --init libs/mpl
-          git submodule update --init libs/multi_index
           git submodule update --init libs/multiprecision
-          git submodule update --init libs/numeric/conversion
-          git submodule update --init libs/numeric/interval
-          git submodule update --init libs/optional
-          git submodule update --init libs/phoenix
-          git submodule update --init libs/pool
-          git submodule update --init libs/predef
-          git submodule update --init libs/preprocessor
-          git submodule update --init libs/property_tree
-          git submodule update --init libs/proto
-          git submodule update --init libs/random
-          git submodule update --init libs/range
-          git submodule update --init libs/ratio
-          git submodule update --init libs/rational
-          git submodule update --init libs/regex
-          git submodule update --init libs/serialization
-          git submodule update --init libs/smart_ptr
-          git submodule update --init libs/spirit
-          git submodule update --init libs/static_assert
-          git submodule update --init libs/system
-          git submodule update --init libs/thread
-          git submodule update --init libs/throw_exception
-          git submodule update --init libs/tokenizer
-          git submodule update --init libs/tti
-          git submodule update --init libs/tuple
-          git submodule update --init libs/type_index
-          git submodule update --init libs/type_traits
-          git submodule update --init libs/typeof
-          git submodule update --init libs/unordered
-          git submodule update --init libs/utility
-          git submodule update --init libs/variant
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-ubsan-limb_type_uint64_t
@@ -735,77 +273,11 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
-          git submodule update --init libs/algorithm
-          git submodule update --init libs/align
-          git submodule update --init libs/any
-          git submodule update --init libs/array
           git submodule update --init libs/assert
-          git submodule update --init libs/atomic
-          git submodule update --init libs/bind
-          git submodule update --init libs/chrono
-          git submodule update --init libs/circular_buffer
-          git submodule update --init libs/compute
-          git submodule update --init libs/concept_check
           git submodule update --init libs/config
-          git submodule update --init libs/container
-          git submodule update --init libs/container_hash
-          git submodule update --init libs/conversion
           git submodule update --init libs/core
-          git submodule update --init libs/date_time
-          git submodule update --init libs/detail
-          git submodule update --init libs/dynamic_bitset
-          git submodule update --init libs/endian
           git submodule update --init libs/exception
-          git submodule update --init libs/foreach
-          git submodule update --init libs/format
-          git submodule update --init libs/function
-          git submodule update --init libs/function_types
-          git submodule update --init libs/fusion
-          git submodule update --init libs/hana
-          git submodule update --init libs/headers
-          git submodule update --init libs/integer
-          git submodule update --init libs/intrusive
-          git submodule update --init libs/io
-          git submodule update --init libs/iterator
-          git submodule update --init libs/lambda
-          git submodule update --init libs/lexical_cast
-          git submodule update --init libs/logic
-          git submodule update --init libs/math
-          git submodule update --init libs/move
-          git submodule update --init libs/mp11
-          git submodule update --init libs/mpl
-          git submodule update --init libs/multi_index
           git submodule update --init libs/multiprecision
-          git submodule update --init libs/numeric/conversion
-          git submodule update --init libs/numeric/interval
-          git submodule update --init libs/optional
-          git submodule update --init libs/phoenix
-          git submodule update --init libs/pool
-          git submodule update --init libs/predef
-          git submodule update --init libs/preprocessor
-          git submodule update --init libs/property_tree
-          git submodule update --init libs/proto
-          git submodule update --init libs/random
-          git submodule update --init libs/range
-          git submodule update --init libs/ratio
-          git submodule update --init libs/rational
-          git submodule update --init libs/regex
-          git submodule update --init libs/serialization
-          git submodule update --init libs/smart_ptr
-          git submodule update --init libs/spirit
-          git submodule update --init libs/static_assert
-          git submodule update --init libs/system
-          git submodule update --init libs/thread
-          git submodule update --init libs/throw_exception
-          git submodule update --init libs/tokenizer
-          git submodule update --init libs/tti
-          git submodule update --init libs/tuple
-          git submodule update --init libs/type_index
-          git submodule update --init libs/type_traits
-          git submodule update --init libs/typeof
-          git submodule update --init libs/unordered
-          git submodule update --init libs/utility
-          git submodule update --init libs/variant
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-tsan
@@ -836,77 +308,11 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
-          git submodule update --init libs/algorithm
-          git submodule update --init libs/align
-          git submodule update --init libs/any
-          git submodule update --init libs/array
           git submodule update --init libs/assert
-          git submodule update --init libs/atomic
-          git submodule update --init libs/bind
-          git submodule update --init libs/chrono
-          git submodule update --init libs/circular_buffer
-          git submodule update --init libs/compute
-          git submodule update --init libs/concept_check
           git submodule update --init libs/config
-          git submodule update --init libs/container
-          git submodule update --init libs/container_hash
-          git submodule update --init libs/conversion
           git submodule update --init libs/core
-          git submodule update --init libs/date_time
-          git submodule update --init libs/detail
-          git submodule update --init libs/dynamic_bitset
-          git submodule update --init libs/endian
           git submodule update --init libs/exception
-          git submodule update --init libs/foreach
-          git submodule update --init libs/format
-          git submodule update --init libs/function
-          git submodule update --init libs/function_types
-          git submodule update --init libs/fusion
-          git submodule update --init libs/hana
-          git submodule update --init libs/headers
-          git submodule update --init libs/integer
-          git submodule update --init libs/intrusive
-          git submodule update --init libs/io
-          git submodule update --init libs/iterator
-          git submodule update --init libs/lambda
-          git submodule update --init libs/lexical_cast
-          git submodule update --init libs/logic
-          git submodule update --init libs/math
-          git submodule update --init libs/move
-          git submodule update --init libs/mp11
-          git submodule update --init libs/mpl
-          git submodule update --init libs/multi_index
           git submodule update --init libs/multiprecision
-          git submodule update --init libs/numeric/conversion
-          git submodule update --init libs/numeric/interval
-          git submodule update --init libs/optional
-          git submodule update --init libs/phoenix
-          git submodule update --init libs/pool
-          git submodule update --init libs/predef
-          git submodule update --init libs/preprocessor
-          git submodule update --init libs/property_tree
-          git submodule update --init libs/proto
-          git submodule update --init libs/random
-          git submodule update --init libs/range
-          git submodule update --init libs/ratio
-          git submodule update --init libs/rational
-          git submodule update --init libs/regex
-          git submodule update --init libs/serialization
-          git submodule update --init libs/smart_ptr
-          git submodule update --init libs/spirit
-          git submodule update --init libs/static_assert
-          git submodule update --init libs/system
-          git submodule update --init libs/thread
-          git submodule update --init libs/throw_exception
-          git submodule update --init libs/tokenizer
-          git submodule update --init libs/tti
-          git submodule update --init libs/tuple
-          git submodule update --init libs/type_index
-          git submodule update --init libs/type_traits
-          git submodule update --init libs/typeof
-          git submodule update --init libs/unordered
-          git submodule update --init libs/utility
-          git submodule update --init libs/variant
           ./bootstrap.sh
           ./b2 headers
       - name: apple-gcc-clang-native
@@ -929,77 +335,11 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
-          git submodule update --init libs/algorithm
-          git submodule update --init libs/align
-          git submodule update --init libs/any
-          git submodule update --init libs/array
           git submodule update --init libs/assert
-          git submodule update --init libs/atomic
-          git submodule update --init libs/bind
-          git submodule update --init libs/chrono
-          git submodule update --init libs/circular_buffer
-          git submodule update --init libs/compute
-          git submodule update --init libs/concept_check
           git submodule update --init libs/config
-          git submodule update --init libs/container
-          git submodule update --init libs/container_hash
-          git submodule update --init libs/conversion
           git submodule update --init libs/core
-          git submodule update --init libs/date_time
-          git submodule update --init libs/detail
-          git submodule update --init libs/dynamic_bitset
-          git submodule update --init libs/endian
           git submodule update --init libs/exception
-          git submodule update --init libs/foreach
-          git submodule update --init libs/format
-          git submodule update --init libs/function
-          git submodule update --init libs/function_types
-          git submodule update --init libs/fusion
-          git submodule update --init libs/hana
-          git submodule update --init libs/headers
-          git submodule update --init libs/integer
-          git submodule update --init libs/intrusive
-          git submodule update --init libs/io
-          git submodule update --init libs/iterator
-          git submodule update --init libs/lambda
-          git submodule update --init libs/lexical_cast
-          git submodule update --init libs/logic
-          git submodule update --init libs/math
-          git submodule update --init libs/move
-          git submodule update --init libs/mp11
-          git submodule update --init libs/mpl
-          git submodule update --init libs/multi_index
           git submodule update --init libs/multiprecision
-          git submodule update --init libs/numeric/conversion
-          git submodule update --init libs/numeric/interval
-          git submodule update --init libs/optional
-          git submodule update --init libs/phoenix
-          git submodule update --init libs/pool
-          git submodule update --init libs/predef
-          git submodule update --init libs/preprocessor
-          git submodule update --init libs/property_tree
-          git submodule update --init libs/proto
-          git submodule update --init libs/random
-          git submodule update --init libs/range
-          git submodule update --init libs/ratio
-          git submodule update --init libs/rational
-          git submodule update --init libs/regex
-          git submodule update --init libs/serialization
-          git submodule update --init libs/smart_ptr
-          git submodule update --init libs/spirit
-          git submodule update --init libs/static_assert
-          git submodule update --init libs/system
-          git submodule update --init libs/thread
-          git submodule update --init libs/throw_exception
-          git submodule update --init libs/tokenizer
-          git submodule update --init libs/tti
-          git submodule update --init libs/tuple
-          git submodule update --init libs/type_index
-          git submodule update --init libs/type_traits
-          git submodule update --init libs/typeof
-          git submodule update --init libs/unordered
-          git submodule update --init libs/utility
-          git submodule update --init libs/variant
           ./bootstrap.bat
           ./b2 headers
       - uses: actions/checkout@v1
@@ -1028,77 +368,11 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
-          git submodule update --init libs/algorithm
-          git submodule update --init libs/align
-          git submodule update --init libs/any
-          git submodule update --init libs/array
           git submodule update --init libs/assert
-          git submodule update --init libs/atomic
-          git submodule update --init libs/bind
-          git submodule update --init libs/chrono
-          git submodule update --init libs/circular_buffer
-          git submodule update --init libs/compute
-          git submodule update --init libs/concept_check
           git submodule update --init libs/config
-          git submodule update --init libs/container
-          git submodule update --init libs/container_hash
-          git submodule update --init libs/conversion
           git submodule update --init libs/core
-          git submodule update --init libs/date_time
-          git submodule update --init libs/detail
-          git submodule update --init libs/dynamic_bitset
-          git submodule update --init libs/endian
           git submodule update --init libs/exception
-          git submodule update --init libs/foreach
-          git submodule update --init libs/format
-          git submodule update --init libs/function
-          git submodule update --init libs/function_types
-          git submodule update --init libs/fusion
-          git submodule update --init libs/hana
-          git submodule update --init libs/headers
-          git submodule update --init libs/integer
-          git submodule update --init libs/intrusive
-          git submodule update --init libs/io
-          git submodule update --init libs/iterator
-          git submodule update --init libs/lambda
-          git submodule update --init libs/lexical_cast
-          git submodule update --init libs/logic
-          git submodule update --init libs/math
-          git submodule update --init libs/move
-          git submodule update --init libs/mp11
-          git submodule update --init libs/mpl
-          git submodule update --init libs/multi_index
           git submodule update --init libs/multiprecision
-          git submodule update --init libs/numeric/conversion
-          git submodule update --init libs/numeric/interval
-          git submodule update --init libs/optional
-          git submodule update --init libs/phoenix
-          git submodule update --init libs/pool
-          git submodule update --init libs/predef
-          git submodule update --init libs/preprocessor
-          git submodule update --init libs/property_tree
-          git submodule update --init libs/proto
-          git submodule update --init libs/random
-          git submodule update --init libs/range
-          git submodule update --init libs/ratio
-          git submodule update --init libs/rational
-          git submodule update --init libs/regex
-          git submodule update --init libs/serialization
-          git submodule update --init libs/smart_ptr
-          git submodule update --init libs/spirit
-          git submodule update --init libs/static_assert
-          git submodule update --init libs/system
-          git submodule update --init libs/thread
-          git submodule update --init libs/throw_exception
-          git submodule update --init libs/tokenizer
-          git submodule update --init libs/tti
-          git submodule update --init libs/tuple
-          git submodule update --init libs/type_index
-          git submodule update --init libs/type_traits
-          git submodule update --init libs/typeof
-          git submodule update --init libs/unordered
-          git submodule update --init libs/utility
-          git submodule update --init libs/variant
           ./bootstrap.bat
           ./b2 headers
       - name: mingw-winhost-x64

--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -33,6 +33,8 @@ jobs:
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           git submodule update --init libs/random
+          git submodule update --init libs/range
+          git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native
@@ -72,6 +74,8 @@ jobs:
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           git submodule update --init libs/random
+          git submodule update --init libs/range
+          git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-limb_type_uint64_t
@@ -113,6 +117,8 @@ jobs:
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           git submodule update --init libs/random
+          git submodule update --init libs/range
+          git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-x86
@@ -154,6 +160,8 @@ jobs:
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           git submodule update --init libs/random
+          git submodule update --init libs/range
+          git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-10
@@ -193,6 +201,8 @@ jobs:
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           git submodule update --init libs/random
+          git submodule update --init libs/range
+          git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-asan
@@ -232,6 +242,8 @@ jobs:
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           git submodule update --init libs/random
+          git submodule update --init libs/range
+          git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-ubsan
@@ -271,6 +283,8 @@ jobs:
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           git submodule update --init libs/random
+          git submodule update --init libs/range
+          git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-ubsan-limb_type_uint64_t
@@ -310,6 +324,8 @@ jobs:
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           git submodule update --init libs/random
+          git submodule update --init libs/range
+          git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-tsan
@@ -349,6 +365,8 @@ jobs:
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           git submodule update --init libs/random
+          git submodule update --init libs/range
+          git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
       - name: apple-gcc-clang-native
@@ -380,6 +398,8 @@ jobs:
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           git submodule update --init libs/random
+          git submodule update --init libs/range
+          git submodule update --init libs/type_traits
           ./bootstrap.bat
           ./b2 headers
       - uses: actions/checkout@v1
@@ -417,6 +437,8 @@ jobs:
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           git submodule update --init libs/random
+          git submodule update --init libs/range
+          git submodule update --init libs/type_traits
           ./bootstrap.bat
           ./b2 headers
       - name: mingw-winhost-x64

--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -28,6 +28,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
@@ -66,6 +67,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
@@ -106,6 +108,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
@@ -146,6 +149,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
@@ -184,6 +188,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
@@ -222,6 +227,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
@@ -260,6 +266,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
@@ -298,6 +305,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
@@ -336,6 +344,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
@@ -366,6 +375,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
@@ -402,6 +412,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision

--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -36,6 +36,7 @@ jobs:
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/static_assert
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -79,6 +80,7 @@ jobs:
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/static_assert
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -124,6 +126,7 @@ jobs:
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/static_assert
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -169,6 +172,7 @@ jobs:
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/static_assert
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -212,6 +216,7 @@ jobs:
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/static_assert
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -255,6 +260,7 @@ jobs:
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/static_assert
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -298,6 +304,7 @@ jobs:
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/static_assert
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -341,6 +348,7 @@ jobs:
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/static_assert
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -384,6 +392,7 @@ jobs:
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/static_assert
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -419,6 +428,7 @@ jobs:
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/static_assert
           git submodule update --init libs/type_traits
           ./bootstrap.bat
           ./b2 headers
@@ -460,6 +470,7 @@ jobs:
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/static_assert
           git submodule update --init libs/type_traits
           ./bootstrap.bat
           ./b2 headers

--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -43,6 +43,7 @@ jobs:
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
           git submodule update --init libs/numeric/conversion
+          git submodule update --init libs/predef
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
@@ -98,6 +99,7 @@ jobs:
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
           git submodule update --init libs/numeric/conversion
+          git submodule update --init libs/predef
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
@@ -155,6 +157,7 @@ jobs:
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
           git submodule update --init libs/numeric/conversion
+          git submodule update --init libs/predef
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
@@ -212,6 +215,7 @@ jobs:
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
           git submodule update --init libs/numeric/conversion
+          git submodule update --init libs/predef
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
@@ -267,6 +271,7 @@ jobs:
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
           git submodule update --init libs/numeric/conversion
+          git submodule update --init libs/predef
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
@@ -322,6 +327,7 @@ jobs:
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
           git submodule update --init libs/numeric/conversion
+          git submodule update --init libs/predef
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
@@ -377,6 +383,7 @@ jobs:
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
           git submodule update --init libs/numeric/conversion
+          git submodule update --init libs/predef
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
@@ -432,6 +439,7 @@ jobs:
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
           git submodule update --init libs/numeric/conversion
+          git submodule update --init libs/predef
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
@@ -487,6 +495,7 @@ jobs:
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
           git submodule update --init libs/numeric/conversion
+          git submodule update --init libs/predef
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
@@ -534,6 +543,7 @@ jobs:
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
           git submodule update --init libs/numeric/conversion
+          git submodule update --init libs/predef
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
@@ -587,6 +597,7 @@ jobs:
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
           git submodule update --init libs/numeric/conversion
+          git submodule update --init libs/predef
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range

--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -28,6 +28,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           ./bootstrap.sh
           ./b2 headers
@@ -63,6 +64,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           ./bootstrap.sh
           ./b2 headers
@@ -100,6 +102,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           ./bootstrap.sh
           ./b2 headers
@@ -137,6 +140,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           ./bootstrap.sh
           ./b2 headers
@@ -172,6 +176,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           ./bootstrap.sh
           ./b2 headers
@@ -207,6 +212,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           ./bootstrap.sh
           ./b2 headers
@@ -242,6 +248,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           ./bootstrap.sh
           ./b2 headers
@@ -277,6 +284,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           ./bootstrap.sh
           ./b2 headers
@@ -312,6 +320,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           ./bootstrap.sh
           ./b2 headers
@@ -339,6 +348,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           ./bootstrap.bat
           ./b2 headers
@@ -372,6 +382,7 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/math
           git submodule update --init libs/multiprecision
           ./bootstrap.bat
           ./b2 headers

--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -26,6 +26,7 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
+          git submodule update --init libs/array
           git submodule update --init libs/assert
           git submodule update --init libs/concept_check
           git submodule update --init libs/container
@@ -80,6 +81,7 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
+          git submodule update --init libs/array
           git submodule update --init libs/assert
           git submodule update --init libs/concept_check
           git submodule update --init libs/container
@@ -136,6 +138,7 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
+          git submodule update --init libs/array
           git submodule update --init libs/assert
           git submodule update --init libs/concept_check
           git submodule update --init libs/container
@@ -192,6 +195,7 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
+          git submodule update --init libs/array
           git submodule update --init libs/assert
           git submodule update --init libs/concept_check
           git submodule update --init libs/container
@@ -246,6 +250,7 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
+          git submodule update --init libs/array
           git submodule update --init libs/assert
           git submodule update --init libs/concept_check
           git submodule update --init libs/container
@@ -300,6 +305,7 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
+          git submodule update --init libs/array
           git submodule update --init libs/assert
           git submodule update --init libs/concept_check
           git submodule update --init libs/container
@@ -354,6 +360,7 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
+          git submodule update --init libs/array
           git submodule update --init libs/assert
           git submodule update --init libs/concept_check
           git submodule update --init libs/container
@@ -408,6 +415,7 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
+          git submodule update --init libs/array
           git submodule update --init libs/assert
           git submodule update --init libs/concept_check
           git submodule update --init libs/container
@@ -462,6 +470,7 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
+          git submodule update --init libs/array
           git submodule update --init libs/assert
           git submodule update --init libs/concept_check
           git submodule update --init libs/container
@@ -508,6 +517,7 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
+          git submodule update --init libs/array
           git submodule update --init libs/assert
           git submodule update --init libs/concept_check
           git submodule update --init libs/container
@@ -560,6 +570,7 @@ jobs:
           git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
           cd ../boost-root
           git submodule update --init tools
+          git submodule update --init libs/array
           git submodule update --init libs/assert
           git submodule update --init libs/concept_check
           git submodule update --init libs/container

--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - '**'
   pull_request:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
 jobs:
   gcc-clang-native:
     runs-on: ubuntu-20.04
@@ -25,18 +27,26 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
+          git submodule update --init libs/detail
           git submodule update --init libs/exception
+          git submodule update --init libs/functional
+          git submodule update --init libs/integer
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/move
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/numeric/conversion
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/rational
           git submodule update --init libs/static_assert
+          git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -69,18 +79,26 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
+          git submodule update --init libs/detail
           git submodule update --init libs/exception
+          git submodule update --init libs/functional
+          git submodule update --init libs/integer
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/move
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/numeric/conversion
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/rational
           git submodule update --init libs/static_assert
+          git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -115,18 +133,26 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
+          git submodule update --init libs/detail
           git submodule update --init libs/exception
+          git submodule update --init libs/functional
+          git submodule update --init libs/integer
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/move
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/numeric/conversion
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/rational
           git submodule update --init libs/static_assert
+          git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -161,18 +187,26 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
+          git submodule update --init libs/detail
           git submodule update --init libs/exception
+          git submodule update --init libs/functional
+          git submodule update --init libs/integer
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/move
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/numeric/conversion
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/rational
           git submodule update --init libs/static_assert
+          git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -205,18 +239,26 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
+          git submodule update --init libs/detail
           git submodule update --init libs/exception
+          git submodule update --init libs/functional
+          git submodule update --init libs/integer
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/move
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/numeric/conversion
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/rational
           git submodule update --init libs/static_assert
+          git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -249,18 +291,26 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
+          git submodule update --init libs/detail
           git submodule update --init libs/exception
+          git submodule update --init libs/functional
+          git submodule update --init libs/integer
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/move
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/numeric/conversion
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/rational
           git submodule update --init libs/static_assert
+          git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -293,18 +343,26 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
+          git submodule update --init libs/detail
           git submodule update --init libs/exception
+          git submodule update --init libs/functional
+          git submodule update --init libs/integer
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/move
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/numeric/conversion
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/rational
           git submodule update --init libs/static_assert
+          git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -337,18 +395,26 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
+          git submodule update --init libs/detail
           git submodule update --init libs/exception
+          git submodule update --init libs/functional
+          git submodule update --init libs/integer
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/move
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/numeric/conversion
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/rational
           git submodule update --init libs/static_assert
+          git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -381,18 +447,26 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
+          git submodule update --init libs/detail
           git submodule update --init libs/exception
+          git submodule update --init libs/functional
+          git submodule update --init libs/integer
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/move
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/numeric/conversion
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/rational
           git submodule update --init libs/static_assert
+          git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
           ./bootstrap.sh
           ./b2 headers
@@ -417,18 +491,26 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
+          git submodule update --init libs/detail
           git submodule update --init libs/exception
+          git submodule update --init libs/functional
+          git submodule update --init libs/integer
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/move
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/numeric/conversion
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/rational
           git submodule update --init libs/static_assert
+          git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
           ./bootstrap.bat
           ./b2 headers
@@ -459,18 +541,26 @@ jobs:
           cd ../boost-root
           git submodule update --init tools
           git submodule update --init libs/assert
+          git submodule update --init libs/container
           git submodule update --init libs/config
           git submodule update --init libs/core
+          git submodule update --init libs/detail
           git submodule update --init libs/exception
+          git submodule update --init libs/functional
+          git submodule update --init libs/integer
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/move
           git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/numeric/conversion
           git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
+          git submodule update --init libs/rational
           git submodule update --init libs/static_assert
+          git submodule update --init libs/throw_exception
           git submodule update --init libs/type_traits
           ./bootstrap.bat
           ./b2 headers

--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -31,7 +31,9 @@ jobs:
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
           git submodule update --init libs/type_traits
@@ -72,7 +74,9 @@ jobs:
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
           git submodule update --init libs/type_traits
@@ -115,7 +119,9 @@ jobs:
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
           git submodule update --init libs/type_traits
@@ -158,7 +164,9 @@ jobs:
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
           git submodule update --init libs/type_traits
@@ -199,7 +207,9 @@ jobs:
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
           git submodule update --init libs/type_traits
@@ -240,7 +250,9 @@ jobs:
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
           git submodule update --init libs/type_traits
@@ -281,7 +293,9 @@ jobs:
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
           git submodule update --init libs/type_traits
@@ -322,7 +336,9 @@ jobs:
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
           git submodule update --init libs/type_traits
@@ -363,7 +379,9 @@ jobs:
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
           git submodule update --init libs/type_traits
@@ -396,7 +414,9 @@ jobs:
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
           git submodule update --init libs/type_traits
@@ -435,7 +455,9 @@ jobs:
           git submodule update --init libs/iterator
           git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
+          git submodule update --init libs/mpl
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/preprocessor
           git submodule update --init libs/random
           git submodule update --init libs/range
           git submodule update --init libs/type_traits

--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -28,8 +28,10 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/random
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native
@@ -64,8 +66,10 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/random
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-limb_type_uint64_t
@@ -102,8 +106,10 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/random
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-x86
@@ -140,8 +146,10 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/random
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-10
@@ -176,8 +184,10 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/random
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-asan
@@ -212,8 +222,10 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/random
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-ubsan
@@ -248,8 +260,10 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/random
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-ubsan-limb_type_uint64_t
@@ -284,8 +298,10 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/random
           ./bootstrap.sh
           ./b2 headers
       - name: gcc-clang-native-tsan
@@ -320,8 +336,10 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/random
           ./bootstrap.sh
           ./b2 headers
       - name: apple-gcc-clang-native
@@ -348,8 +366,10 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/random
           ./bootstrap.bat
           ./b2 headers
       - uses: actions/checkout@v1
@@ -382,8 +402,10 @@ jobs:
           git submodule update --init libs/config
           git submodule update --init libs/core
           git submodule update --init libs/exception
+          git submodule update --init libs/lexical_cast
           git submodule update --init libs/math
           git submodule update --init libs/multiprecision
+          git submodule update --init libs/random
           ./bootstrap.bat
           ./b2 headers
       - name: mingw-winhost-x64

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ It is hoped that the examples provide inspiration and guidance
 on how to use wide-integer.
 
   - ![`example000_numeric_limits.cpp`](./examples/example000_numeric_limits.cpp) verifies parts of the specializations of `std::numeric_limits` for (unsigned) `uint256_t`and (signed) `int256_t`.
-  - ![`example000a_builtin_convert.cpp`](./examples/example000a_builtin_convert.cpp) exercises some conversions to/from (signed) `int256_t`and (signed) `int256_t`.
+  - ![`example000a_builtin_convert.cpp`](./examples/example000a_builtin_convert.cpp) exercises some conversions to/from built-in types/`uintwide_t`.
   - ![`example001_mul_div.cpp`](./examples/example001_mul_div.cpp) performs multiplication and division.
   - ![`example001a_div_mod.cpp`](./examples/example001a_div_mod.cpp) exercises division and modulus calculations.
   - ![`example002_shl_shr.cpp`](./examples/example002_shl_shr.cpp) does a few left and right shift operations.


### PR DESCRIPTION
At the moment this is cycling through CI.

When working on this activity it was noted that using Boost.Random pulled in a significant number of the Boost dependencies. These could be reduced if local replacements for the random functions needed from Boost were to be implemented in the project itself.
