### PR TITLE
Fix the CMake install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,12 @@ target_include_directories(
   $<INSTALL_INTERFACE:include>)
 
 install(TARGETS WideInteger EXPORT WideIntegerTargets)
-install(DIRECTORY include/ DESTINATION include)
+install(
+  FILES math/wide_integer/uintwide_t.h
+  DESTINATION include/math/wide_integer/)
+install(
+  FILES util/utility/util_dynamic_array.h
+  DESTINATION include/util/utility/)
 install(EXPORT WideIntegerTargets
   FILE WideIntegerConfig.cmake
   NAMESPACE WideInteger::


### PR DESCRIPTION
This wasn't set correctly at all but it wasn't used so I didn't notice. Now, it ensures that if the install path is _/usr/_ (the default on a lot of systems), then the library will be installed as

```
usr
├── include
│   ├── math
│   │   └── wide_integer
│   │       └── uintwide_t.h
│   └── util
│       └── utility
│           └── util_dynamic_array.h
└── lib
    └── cmake
        └── wide-integer
            └── WideIntegerConfig.cmake
```

... and will actually work!