### PR TITLE
Use default copy and move constructors, assignment operators

### DIFF
--- a/math/wide_integer/uintwide_t.h
+++ b/math/wide_integer/uintwide_t.h
@@ -481,8 +481,7 @@
                 value_type());
     }
 
-    constexpr fixed_static_array(const fixed_static_array& other_array)
-      : base_class_type(static_cast<const base_class_type&>(other_array)) { }
+    constexpr fixed_static_array(const fixed_static_array& other_array) = default;
 
     template<const size_type OtherSize>
     WIDE_INTEGER_CONSTEXPR fixed_static_array(const fixed_static_array<size_type, OtherSize>& other_array)
@@ -507,22 +506,10 @@
                 value_type());
     }
 
-    constexpr fixed_static_array(fixed_static_array&& other_array)
-      : base_class_type(static_cast<base_class_type&&>(other_array)) { }
+    constexpr fixed_static_array(fixed_static_array&& other_array) = default;
 
-    WIDE_INTEGER_CONSTEXPR fixed_static_array& operator=(const fixed_static_array& other_array)
-    {
-      base_class_type::operator=((const base_class_type&) other_array);
-
-      return *this;
-    }
-
-    WIDE_INTEGER_CONSTEXPR fixed_static_array& operator=(fixed_static_array&& other_array)
-    {
-      base_class_type::operator=((base_class_type&&) other_array);
-
-      return *this;
-    }
+    WIDE_INTEGER_CONSTEXPR fixed_static_array& operator=(const fixed_static_array& other_array) = default;
+    WIDE_INTEGER_CONSTEXPR fixed_static_array& operator=(fixed_static_array&& other_array) = default;
   };
 
   template<const size_t Width2> struct verify_power_of_two_times_granularity_one_sixty_fourth
@@ -938,7 +925,7 @@
     #endif
 
     // Copy constructor.
-    constexpr uintwide_t(const uintwide_t& other) : values(other.values) { }
+    constexpr uintwide_t(const uintwide_t& other) = default;
 
     // Copy-like constructor from the other signed-ness type.
     template<const bool OtherIsSigned,
@@ -972,7 +959,7 @@
     }
 
     // Move constructor.
-    constexpr uintwide_t(uintwide_t&& other) : values(static_cast<representation_type&&>(other.values)) { }
+    constexpr uintwide_t(uintwide_t&& other) = default;
 
     // Move-like constructor from the other signed-ness type.
     template<const bool OtherIsSigned,
@@ -981,15 +968,7 @@
       : values(static_cast<representation_type&&>(other.values)) { }
 
     // Assignment operator.
-    WIDE_INTEGER_CONSTEXPR uintwide_t& operator=(const uintwide_t& other)
-    {
-      if(this != &other)
-      {
-        values = other.values;
-      }
-
-      return *this;
-    }
+    WIDE_INTEGER_CONSTEXPR uintwide_t& operator=(const uintwide_t& other) = default;
 
     // Assignment operator from the other signed-ness type.
     template<const bool OtherIsSigned,
@@ -1002,12 +981,7 @@
     }
 
     // Trivial move assignment operator.
-    WIDE_INTEGER_CONSTEXPR uintwide_t& operator=(uintwide_t&& other)
-    {
-      values = static_cast<representation_type&&>(other.values);
-
-      return *this;
-    }
+    WIDE_INTEGER_CONSTEXPR uintwide_t& operator=(uintwide_t&& other) = default;
 
     // Trivial move assignment operator from the other signed-ness type.
     template<const bool OtherIsSigned,
@@ -3218,6 +3192,9 @@
   using uint8192_t  = uintwide_t< 8192U, std::uint32_t>;
   using uint16384_t = uintwide_t<16384U, std::uint32_t>;
   using uint32768_t = uintwide_t<32768U, std::uint32_t>;
+  static_assert(std::is_trivially_copyable<uint512_t>::value &&
+    std::is_standard_layout<uint512_t>::value,
+    "uintwide_t must be trivially copyable with standard layout.");
 
   using  int64_t    = uintwide_t<   64U, std::uint16_t, void, true>;
   using  int128_t   = uintwide_t<  128U, std::uint32_t, void, true>;
@@ -3229,6 +3206,9 @@
   using  int8192_t  = uintwide_t< 8192U, std::uint32_t, void, true>;
   using  int16384_t = uintwide_t<16384U, std::uint32_t, void, true>;
   using  int32768_t = uintwide_t<32768U, std::uint32_t, void, true>;
+  static_assert(std::is_trivially_copyable<int512_t>::value &&
+    std::is_standard_layout<int512_t>::value,
+    "uintwide_t must be trivially copyable with standard layout.");
 
   // Insert a base class for numeric_limits<> support.
   // This class inherits from std::numeric_limits<unsigned int>


### PR DESCRIPTION
This allows `uintwide_t` to be trivially copyable.

Static asserting trivially copyable and standard layout ensures
that objects of `uintwide_t` can be exchanged with extern C
functions.