### PR TITLE
Preparing boost 1 77

### DIFF
--- a/boost/multiprecision/uintwide_t_backend.hpp
+++ b/boost/multiprecision/uintwide_t_backend.hpp
@@ -20,6 +20,8 @@
   #pragma GCC diagnostic ignored "-Wconversion"
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wsign-conversion"
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
   #endif
 
   #if defined(__clang__) && !defined(__APPLE__)
@@ -628,6 +630,7 @@
   #endif
 
   #if defined(__GNUC__)
+  #pragma GCC diagnostic pop
   #pragma GCC diagnostic pop
   #pragma GCC diagnostic pop
   #endif

--- a/boost/multiprecision/uintwide_t_backend.hpp
+++ b/boost/multiprecision/uintwide_t_backend.hpp
@@ -13,6 +13,8 @@
   #include <string>
   #include <type_traits>
 
+  // testing develop on its way to 1.77
+
   #if defined(__GNUC__)
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wconversion"

--- a/examples/example008a_miller_rabin_prime.cpp
+++ b/examples/example008a_miller_rabin_prime.cpp
@@ -18,6 +18,8 @@
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 
 #if defined(__clang__) && !defined(__APPLE__)
@@ -103,6 +105,7 @@ int main()
 #endif
 
 #if defined(__GNUC__)
+#pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #endif

--- a/test/test_uintwide_t_boost_backend.cpp
+++ b/test/test_uintwide_t_boost_backend.cpp
@@ -10,6 +10,8 @@
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 
 #if defined(__clang__) && !defined(__APPLE__)
@@ -88,6 +90,7 @@ bool math::wide_integer::test_uintwide_t_boost_backend()
 #endif
 
 #if defined(__GNUC__)
+#pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #endif

--- a/test/test_uintwide_t_edge_cases.cpp
+++ b/test/test_uintwide_t_edge_cases.cpp
@@ -12,6 +12,8 @@
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 
 #if defined(__clang__) && !defined(__APPLE__)
@@ -144,6 +146,7 @@ bool math::wide_integer::test_uintwide_t_edge_cases()
 #endif
 
 #if defined(__GNUC__)
+#pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #endif

--- a/test/test_uintwide_t_float_convert.cpp
+++ b/test/test_uintwide_t_float_convert.cpp
@@ -16,6 +16,8 @@
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 
 #if defined(__clang__) && !defined(__APPLE__)
@@ -273,6 +275,7 @@ bool math::wide_integer::test_uintwide_t_float_convert()
 #endif
 
 #if defined(__GNUC__)
+#pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #endif

--- a/test/test_uintwide_t_n_base.h
+++ b/test/test_uintwide_t_n_base.h
@@ -17,6 +17,8 @@
   #pragma GCC diagnostic ignored "-Wconversion"
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wsign-conversion"
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wunused-parameter"
   #endif
 
   #if defined(__clang__) && !defined(__APPLE__)
@@ -114,6 +116,7 @@
   #endif
 
   #if defined(__GNUC__)
+  #pragma GCC diagnostic pop
   #pragma GCC diagnostic pop
   #pragma GCC diagnostic pop
   #endif

--- a/test/test_uintwide_t_n_binary_ops_base.cpp
+++ b/test/test_uintwide_t_n_binary_ops_base.cpp
@@ -10,6 +10,8 @@
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 
 #if defined(__clang__) && !defined(__APPLE__)
@@ -28,6 +30,7 @@ test_uintwide_t_n_binary_ops_base::random_generator_type test_uintwide_t_n_binar
 #endif
 
 #if defined(__GNUC__)
+#pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
Recent changes in Boost-develop branch (preparing for Boost 1.77) introduce new warnings.
Since CI runs with -Werror, these need to be disabled in Boost-related tests.