### PR TITLE
Add header search paths as system paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(WideInteger INTERFACE)
 target_compile_features(WideInteger INTERFACE cxx_std_11)
 
 target_include_directories(
-  WideInteger INTERFACE
+  WideInteger SYSTEM INTERFACE
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include>)
 


### PR DESCRIPTION
Ensures that warnings are not emitted in client code for issues identified in them. In particular, Clang-Tidy is complaining about _uintwide_t.h_ ([example](https://github.com/johnmcfarlane/cnl/runs/4146050635?check_suite_focus=true#step:8:86)) because it assumes it's part of the CNL project.