### PR TITLE
Remove unused/broken references to util_dynamic_array.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,6 @@ install(TARGETS WideInteger EXPORT WideIntegerTargets)
 install(
   FILES math/wide_integer/uintwide_t.h
   DESTINATION include/math/wide_integer/)
-install(
-  FILES util/utility/util_dynamic_array.h
-  DESTINATION include/util/utility/)
 install(EXPORT WideIntegerTargets
   FILE WideIntegerConfig.cmake
   NAMESPACE WideInteger::

--- a/examples/example012_rsa_crypto.cpp
+++ b/examples/example012_rsa_crypto.cpp
@@ -10,7 +10,6 @@
 
 #include <examples/example_uintwide_t.h>
 #include <math/wide_integer/uintwide_t.h>
-//#include <util/utility/util_dynamic_array.h>
 
 namespace local_rsa
 {


### PR DESCRIPTION
I assume that external sources of _util_dynamic_array.h_ still exist. If not, I'm happy to remove the preprocessor macro related to this also.