### PR TITLE
Replace protected with private

### DIFF
--- a/math/wide_integer/uintwide_t.h
+++ b/math/wide_integer/uintwide_t.h
@@ -315,7 +315,7 @@
       other.elems      = tmp_elems;
     }
 
-  protected:
+  private:
     mutable size_type elem_count;
     pointer           elems;
   };


### PR DESCRIPTION
I think I mentioned this in the review of the Clang-Tidy fixups.

I've heard that the company that originally pushed hard to include `protected` in C++98 subsequently banned it from their own codebase!

Anyway, I've managed to avoid ever using protected in a class and I feel that it's forced me to find simpler ways to arrange things. Highly recommended!