### PR TITLE
Remove NOLINT markers from main header

### DIFF
--- a/math/wide_integer/uintwide_t.h
+++ b/math/wide_integer/uintwide_t.h
@@ -1,5 +1,3 @@
-// NOLINTBEGIN(*)
-// copied from https://github.com/ckormanyos/wide-integer/
 
 ///////////////////////////////////////////////////////////////////
 //  Copyright Christopher Kormanyos 1999 - 2022.                 //
@@ -5318,4 +5316,3 @@
   WIDE_INTEGER_NAMESPACE_END
 
 #endif // UINTWIDE_T_2018_10_02_H_
-// NOLINTEND(*)


### PR DESCRIPTION
The markers at either end of the file were added in error.
They are meant to be added automatically when copying the file from wide-integer.
When left in wide-integer, they will cause Clang-Tidy to ignore *all checks* in this file!