### PR TITLE
Fix broken CMake job

### DIFF
--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -35,6 +35,11 @@ jobs:
       - name: create build directory
         run: mkdir $GITHUB_WORKSPACE/build
 
+      - name: install Boost
+        run: |
+          apt-get update --quiet
+          apt-get install --no-install-recommends --quiet --yes libboost-dev
+
       - name: build
         working-directory: build
         run: |


### PR DESCRIPTION
I've figured out why existing pipeline was not finding Clang-Tidy errors: Boost was removed from the CMake job so no tests were built/run! This adds Boost back into the CMake job.