### PR TITLE
Refine tidy and outer namespace fixes

### DIFF
--- a/.github/workflows/wide_integer.yml
+++ b/.github/workflows/wide_integer.yml
@@ -35,6 +35,11 @@ jobs:
       - name: create build directory
         run: mkdir $GITHUB_WORKSPACE/build
 
+      - name: install Boost
+        run: |
+          apt-get update --quiet
+          apt-get install --no-install-recommends --quiet --yes libboost-dev
+
       - name: build
         working-directory: build
         run: |

--- a/README.md
+++ b/README.md
@@ -398,9 +398,9 @@ We recall that all parts of the wide-integer implementation,
 such as the `uintwide_t` class and its associated implementation
 details reside within `namespace` `::math::wide_integer`
 Defining the macro `WIDE_INTEGER_NAMESPACE` to be something like,
-for instance, `-DWIDE_INTEGER_NAMESPACE=whatever_unique` places
+for instance, `-DWIDE_INTEGER_NAMESPACE=something_unique` places
 all parts of the wide-integer implementation and its details
-within an outer `namespace` such as `whatever_unique::math::wide_integer`.
+within the outer `namespace` `something_unique::math::wide_integer`.
 
 The macro `WIDE_INTEGER_NAMESPACE` is defined (but defined to be nothing, i.e., empty)
 by default. In this default state, `namespace` `::math::wide_integer` is used

--- a/README.md
+++ b/README.md
@@ -400,10 +400,14 @@ details reside within `namespace` `::math::wide_integer`
 Defining the macro `WIDE_INTEGER_NAMESPACE` to be something like,
 for instance, `-DWIDE_INTEGER_NAMESPACE=something_unique` places
 all parts of the wide-integer implementation and its details
-within the outer `namespace` `something_unique::math::wide_integer`.
+within the prepended outer namespace `something_unique` ---
+as in `namespace` `::something_unique::math::wide_integer`.
+Vary the actual name or nesting depth of the desired prepended
+outer namespace if/as needed for your project.
 
-The macro `WIDE_INTEGER_NAMESPACE` is defined (but defined to be nothing, i.e., empty)
-by default. In this default state, `namespace` `::math::wide_integer` is used
+By default the macro `WIDE_INTEGER_NAMESPACE` is defined
+(but defined to be nothing, i.e., empty).
+In this default state, `namespace` `::math::wide_integer` is used
 and the `uintwide_t` class and its associated implementation
 details reside therein.
 

--- a/boost/multiprecision/uintwide_t_backend.hpp
+++ b/boost/multiprecision/uintwide_t_backend.hpp
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////
 //  Copyright Christopher Kormanyos 2019 - 2022.                 //
 //  Distributed under the Boost Software License,                //
 //  Version 1.0. (See accompanying file LICENSE_1_0.txt          //
@@ -34,10 +34,8 @@
   #include <math/wide_integer/uintwide_t.h>
 
   #if defined(WIDE_INTEGER_NAMESPACE)
-  #if (~(~WIDE_INTEGER_NAMESPACE + 0) == 0 && ~(~WIDE_INTEGER_NAMESPACE + 1) == 1)
-  #else
   using namespace WIDE_INTEGER_NAMESPACE;
-  #endif
+  #else
   #endif
 
   namespace boost { namespace multiprecision {

--- a/examples/example_uintwide_t.h
+++ b/examples/example_uintwide_t.h
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////
 //  Copyright Christopher Kormanyos 2021.                        //
 //  Distributed under the Boost Software License,                //
 //  Version 1.0. (See accompanying file LICENSE_1_0.txt          //
@@ -43,10 +43,8 @@
   WIDE_INTEGER_NAMESPACE_END
 
   #if defined(WIDE_INTEGER_NAMESPACE)
-  #if (~(~WIDE_INTEGER_NAMESPACE + 0) == 0 && ~(~WIDE_INTEGER_NAMESPACE + 1) == 1)
-  #else
   using namespace WIDE_INTEGER_NAMESPACE;
-  #endif
+  #else
   #endif
 
 #endif // EXAMPLE_UINTWIDE_T_2021_04_29_H

--- a/math/wide_integer/uintwide_t.h
+++ b/math/wide_integer/uintwide_t.h
@@ -99,9 +99,9 @@
     #define WIDE_INTEGER_NAMESPACE_END
   #endif
 
-  WIDE_INTEGER_NAMESPACE_BEGIN
-
   #if !defined(WIDE_INTEGER_DISABLE_IMPLEMENT_UTIL_DYNAMIC_ARRAY)
+
+  WIDE_INTEGER_NAMESPACE_BEGIN
 
   namespace util {
 
@@ -435,17 +435,47 @@
 
   } // namespace util
 
-  #else
+  WIDE_INTEGER_NAMESPACE_END
 
-  #include <util/utility/util_dynamic_array.h>
-
-  #endif
+  WIDE_INTEGER_NAMESPACE_BEGIN
 
   namespace math { namespace wide_integer {
 
   namespace detail {
 
   using util::dynamic_array;
+
+  } // namespace detail
+  } // namespace wide_integer
+  } // namespace math
+
+  WIDE_INTEGER_NAMESPACE_END
+
+  #else
+
+  #include <util/utility/util_dynamic_array.h>
+
+  WIDE_INTEGER_NAMESPACE_BEGIN
+
+  namespace math { namespace wide_integer {
+
+  namespace detail {
+
+  using util::dynamic_array;
+
+  } // namespace detail
+  } // namespace wide_integer
+  } // namespace math
+
+  WIDE_INTEGER_NAMESPACE_END
+
+  #endif
+
+  WIDE_INTEGER_NAMESPACE_BEGIN
+
+  namespace math { namespace wide_integer {
+
+  namespace detail {
 
   using size_t    = std::uint32_t;
   using ptrdiff_t = std::int32_t;

--- a/math/wide_integer/uintwide_t.h
+++ b/math/wide_integer/uintwide_t.h
@@ -94,7 +94,6 @@
     #define WIDE_INTEGER_NAMESPACE_BEGIN namespace WIDE_INTEGER_NAMESPACE {
     #define WIDE_INTEGER_NAMESPACE_END } /* namespace WIDE_INTEGER_NAMESPACE */
   #else
-    #define WIDE_INTEGER_NAMESPACE
     #define WIDE_INTEGER_NAMESPACE_BEGIN
     #define WIDE_INTEGER_NAMESPACE_END
   #endif
@@ -817,11 +816,19 @@
   namespace std
   {
     // Forward declaration of specialization of std::numeric_limits<uintwide_t>.
+    #if defined(WIDE_INTEGER_NAMESPACE)
     template<const WIDE_INTEGER_NAMESPACE::math::wide_integer::size_t Width2,
              typename LimbType,
              typename AllocatorType,
              const bool IsSigned>
     WIDE_INTEGER_NUM_LIMITS_CLASS_TYPE numeric_limits<WIDE_INTEGER_NAMESPACE::math::wide_integer::uintwide_t<Width2, LimbType, AllocatorType, IsSigned>>;
+    #else
+    template<const ::math::wide_integer::size_t Width2,
+             typename LimbType,
+             typename AllocatorType,
+             const bool IsSigned>
+    WIDE_INTEGER_NUM_LIMITS_CLASS_TYPE numeric_limits<::math::wide_integer::uintwide_t<Width2, LimbType, AllocatorType, IsSigned>>;
+    #endif
   } // namespace std
 
   WIDE_INTEGER_NAMESPACE_BEGIN
@@ -3967,12 +3974,21 @@
   namespace std
   {
     // Specialization of std::numeric_limits<uintwide_t>.
+    #if defined(WIDE_INTEGER_NAMESPACE)
     template<const WIDE_INTEGER_NAMESPACE::math::wide_integer::size_t Width2,
              typename LimbType,
              typename AllocatorType,
              const bool IsSigned>
     WIDE_INTEGER_NUM_LIMITS_CLASS_TYPE numeric_limits<WIDE_INTEGER_NAMESPACE::math::wide_integer::uintwide_t<Width2, LimbType, AllocatorType, IsSigned>>
       : public WIDE_INTEGER_NAMESPACE::math::wide_integer::numeric_limits_uintwide_t_base<Width2, LimbType, AllocatorType, IsSigned> { };
+    #else
+    template<const ::math::wide_integer::size_t Width2,
+             typename LimbType,
+             typename AllocatorType,
+             const bool IsSigned>
+    WIDE_INTEGER_NUM_LIMITS_CLASS_TYPE numeric_limits<::math::wide_integer::uintwide_t<Width2, LimbType, AllocatorType, IsSigned>>
+      : public ::math::wide_integer::numeric_limits_uintwide_t_base<Width2, LimbType, AllocatorType, IsSigned> { };
+    #endif
   } // namespace std
 
   WIDE_INTEGER_NAMESPACE_BEGIN

--- a/test/test_uintwide_t.h
+++ b/test/test_uintwide_t.h
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////
 //  Copyright Christopher Kormanyos 2019 - 2022.                 //
 //  Distributed under the Boost Software License,                //
 //  Version 1.0. (See accompanying file LICENSE_1_0.txt          //
@@ -27,10 +27,8 @@
   WIDE_INTEGER_NAMESPACE_END
 
   #if defined(WIDE_INTEGER_NAMESPACE)
-  #if (~(~WIDE_INTEGER_NAMESPACE + 0) == 0 && ~(~WIDE_INTEGER_NAMESPACE + 1) == 1)
-  #else
   using namespace WIDE_INTEGER_NAMESPACE;
-  #endif
+  #else
   #endif
 
 #endif // TEST_UINTWIDE_T_2019_12_15_H

--- a/test/test_uintwide_t_n_base.h
+++ b/test/test_uintwide_t_n_base.h
@@ -1,4 +1,4 @@
-///////////////////////////////////////////////////////////////////////////////
+﻿///////////////////////////////////////////////////////////////////////////////
 //  Copyright Christopher Kormanyos 2019 - 2022.
 //  Distributed under the Boost Software License,
 //  Version 1.0. (See accompanying file LICENSE_1_0.txt
@@ -32,10 +32,8 @@
   #include <test/parallel_for.h>
 
   #if defined(WIDE_INTEGER_NAMESPACE)
-  #if (~(~WIDE_INTEGER_NAMESPACE + 0) == 0 && ~(~WIDE_INTEGER_NAMESPACE + 1) == 1)
-  #else
   using namespace WIDE_INTEGER_NAMESPACE;
-  #endif
+  #else
   #endif
 
   class test_uintwide_t_n_base

--- a/test/test_uintwide_t_spot_values.cpp
+++ b/test/test_uintwide_t_spot_values.cpp
@@ -25,19 +25,19 @@ namespace local
     const auto a0(x);
 
     {
-      local_unknown_integer_type a = a0; a += a;
+      local_unknown_integer_type a = a0; a += a; // NOLINT(clang-diagnostic-self-assign-overloaded)
 
       local_result_is_ok &= (a == (2U * a0));
     }
 
     {
-      local_unknown_integer_type a = a0; a -= a;
+      local_unknown_integer_type a = a0; a -= a; // NOLINT(clang-diagnostic-self-assign-overloaded)
 
       local_result_is_ok &= (a == 0U);
     }
 
     {
-      local_unknown_integer_type a = a0; a /= a;
+      local_unknown_integer_type a = a0; a /= a; // NOLINT(clang-diagnostic-self-assign-overloaded)
 
       local_result_is_ok &= (a == 1U);
     }

--- a/test/test_uintwide_t_spot_values.cpp
+++ b/test/test_uintwide_t_spot_values.cpp
@@ -24,6 +24,11 @@ namespace local
 
     const auto a0(x);
 
+    #if defined(__clang__)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wself-assign-overloaded"
+    #endif
+
     {
       local_unknown_integer_type a = a0; a += a; // NOLINT(clang-diagnostic-self-assign-overloaded)
 
@@ -41,6 +46,10 @@ namespace local
 
       local_result_is_ok &= (a == 1U);
     }
+
+    #if defined(__clang__)
+    #pragma GCC diagnostic pop
+    #endif
 
     return local_result_is_ok;
   }


### PR DESCRIPTION
This PR further refines the `clang-tidy` and outer-namespace fixes.

It properly handles `util::dynamic_array` for systems such as embedded systems using it.

It also includes the CMake tidy fix of #167 and also `NOLINT`s the `clang-tidy`messages found in the CI jobs thereof.

Cc: @johnmcfarlane 