### PR TITLE
Fix for hard-to-reach Clang-Tidy diagnostic

### DIFF
--- a/math/wide_integer/uintwide_t.h
+++ b/math/wide_integer/uintwide_t.h
@@ -10,7 +10,7 @@
 
   #if defined(__GNUC__) || defined(__clang__)
   #if defined(WIDE_INTEGER_HAS_LIMB_TYPE_UINT64)
-  #include <inttypes.h>
+  #include <cinttypes>
   #endif
   #endif
 


### PR DESCRIPTION
From clang-tidy at head (1d4ca42b43805f7199b921f35c1257b2cbad72c9):

> /home/john/ws/wide-int/cnl/include/cnl/_impl/ckormanyos/uintwide_t.h:13:12: error: inclusion of deprecated C++ header 'inttypes.h'; consider using 'cinttypes' instead [hicpp-deprecated-headers,modernize-deprecated-headers,-warnings-as-errors]

I'm guessing I don't compile with the pre-processor combination necessary to catch this in CI.