### PR TITLE
Improve CMake scripts for using as subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,22 @@ project(wide-integer)
 
 cmake_minimum_required(VERSION 3.16.3)
 
-find_package(Boost)
-if (Boost_FOUND)
-  include(CTest)
+if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
+  set(WIDE_INTEGER_MASTER_PROJECT ON)
+else()
+  set(WIDE_INTEGER_MASTER_PROJECT OFF)
+endif()
 
-  add_subdirectory("examples")
-  add_subdirectory("test")
+option(ENABLE_TESTS "Enable/disable tests" ${WIDE_INTEGER_MASTER_PROJECT})
+
+if (ENABLE_TESTS)
+  find_package(Boost)
+  if (Boost_FOUND)
+    include(CTest)
+
+    add_subdirectory("examples")
+    add_subdirectory("test")
+  endif()
 endif()
 
 add_library(WideInteger INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ target_include_directories(
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include>)
 
+add_library(WideInteger::WideInteger ALIAS WideInteger)
+
 install(TARGETS WideInteger EXPORT WideIntegerTargets)
 install(
   FILES math/wide_integer/uintwide_t.h


### PR DESCRIPTION
These changes allow other projects to include this project within the build tree (e.g. using git submodules) and use it like this:

```cmake
add_subdirectory(wide-integer)
```

The effect will be the same as installing this project and then doing:

```cmake
find_package(WideInteger)
```