### PR TITLE
Uint defaultlimb t

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,13 @@ using detail::size_t;
 
 // Forward declaration of the uintwide_t template class.
 template<const size_t Width2,
-         typename LimbType      = std::uint32_t,
+         typename LimbType      = uint_defaultlimb_t,
          typename AllocatorType = void,
          const bool IsSigned    = false>
 class uintwide_t;
+
+// Here, uint_defaultlimb_t is either std::uint32_t or std::uint64_t
+// (if WIDE_INTEGER_HAS_LIMB_TYPE_UINT64, see below) is defined.
 
 } // namespace math::wide_integer
 ```
@@ -665,7 +668,7 @@ Otherwise, the header file `<util/utility/util_dynamic_array.h>`
 must be found in the include path.
 
 When working on high-performance systems having `unsigned __int128`
-(an extended-width, yet non-standard data type),
+(an extended-width, yet non-standard data type) or `std::Unsigned128`,
 a 64-bit limb of type `uint64_t` can be used.
 Enable the 64-bit limb type on such systems
 with the compiler switch:
@@ -682,6 +685,8 @@ command line with:
 ```
 
 This macro is disabled by default.
+The template default limb type, `uint_defaultlimb_t` is either `std::uint32_t`
+or `std::uint64_t` if WIDE_INTEGER_HAS_LIMB_TYPE_UINT64 is defined.
 
 The example below, for instance, uses a 64-bit limb type
 on GCC or clang.

--- a/examples/example009_timed_mul.cpp
+++ b/examples/example009_timed_mul.cpp
@@ -43,10 +43,10 @@ namespace local_timed_mul
     *it_out = distribution(rng);
   }
 
-  #if defined(WIDE_INTEGER_HAS_LIMB_TYPE_UINT64)
-  using local_limb_type = std::uint64_t;
+  #if defined(WIDE_INTEGER_NAMESPACE)
+  using local_limb_type = WIDE_INTEGER_NAMESPACE::math::wide_integer::uint_defaultlimb_t;
   #else
-  using local_limb_type = std::uint32_t;
+  using local_limb_type = ::math::wide_integer::uint_defaultlimb_t;
   #endif
 
   #if defined(WIDE_INTEGER_NAMESPACE)

--- a/examples/example009a_timed_mul_4_by_4.cpp
+++ b/examples/example009a_timed_mul_4_by_4.cpp
@@ -41,10 +41,10 @@ namespace local_timed_mul_4_by_4
     *it_out = distribution(rng);
   }
 
-  #if defined(WIDE_INTEGER_HAS_LIMB_TYPE_UINT64)
-  using local_limb_type = std::uint64_t;
+  #if defined(WIDE_INTEGER_NAMESPACE)
+  using local_limb_type = WIDE_INTEGER_NAMESPACE::math::wide_integer::uint_defaultlimb_t;
   #else
-  using local_limb_type = std::uint32_t;
+  using local_limb_type = ::math::wide_integer::uint_defaultlimb_t;
   #endif
 
   #if defined(WIDE_INTEGER_NAMESPACE)

--- a/examples/example009b_timed_mul_8_by_8.cpp
+++ b/examples/example009b_timed_mul_8_by_8.cpp
@@ -41,10 +41,10 @@ namespace local_timed_mul_8_by_8
     *it_out = distribution(rng);
   }
 
-  #if defined(WIDE_INTEGER_HAS_LIMB_TYPE_UINT64)
-  using local_limb_type = std::uint64_t;
+  #if defined(WIDE_INTEGER_NAMESPACE)
+  using local_limb_type = WIDE_INTEGER_NAMESPACE::math::wide_integer::uint_defaultlimb_t;
   #else
-  using local_limb_type = std::uint32_t;
+  using local_limb_type = ::math::wide_integer::uint_defaultlimb_t;
   #endif
 
   #if defined(WIDE_INTEGER_NAMESPACE)

--- a/math/wide_integer/uintwide_t.h
+++ b/math/wide_integer/uintwide_t.h
@@ -1017,6 +1017,11 @@
 
   using size_t    = std::uint32_t;
   using ptrdiff_t = std::int32_t;
+  #if defined(WIDE_INTEGER_HAS_LIMB_TYPE_UINT64)
+  using uint_defaultlimb_t = std::uint64_t;
+  #else
+  using uint_defaultlimb_t = std::uint32_t;
+  #endif
 
   static_assert((   (std::numeric_limits<size_t>::digits        >= std::numeric_limits<std::uint16_t>::digits)
                  && (std::numeric_limits<ptrdiff_t>::digits + 1 >= std::numeric_limits<std::uint16_t>::digits)),
@@ -1191,10 +1196,11 @@
   using detail::ptrdiff_t;
   using detail::unsigned_fast_type;
   using detail::signed_fast_type;
+  using detail::uint_defaultlimb_t;
 
   // Forward declaration of the uintwide_t template class.
   template<const size_t Width2,
-           typename LimbType = std::uint32_t,
+           typename LimbType = uint_defaultlimb_t,
            typename AllocatorType = void,
            const bool IsSigned = false>
   class uintwide_t;
@@ -1438,13 +1444,13 @@
                         std::enable_if_t<(IsSignedLeft || IsSignedRight), int>* p_nullparam = nullptr) -> std::pair<uintwide_t<Width2, LimbType, AllocatorType, IsSignedLeft>, uintwide_t<Width2, LimbType, AllocatorType, IsSignedRight>>;
 
   template<const size_t Width2,
-           typename LimbType = std::uint32_t,
+           typename LimbType = uint_defaultlimb_t,
            typename AllocatorType = void,
            const bool IsSigned = false>
   class default_random_engine;
 
   template<const size_t Width2,
-           typename LimbType = std::uint32_t,
+           typename LimbType = uint_defaultlimb_t,
            typename AllocatorType = void,
            const bool IsSigned = false>
   class uniform_int_distribution;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -522,12 +522,14 @@ auto test_uintwide_t_0065536_alloc() -> bool
   constexpr auto count = static_cast<std::size_t>(1UL << 2U); // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
   #endif
 
-  std::cout << "running: test_uintwide_t_0065536_alloc" << std::endl;
-  #if defined(WIDE_INTEGER_HAS_LIMB_TYPE_UINT64)
-  test_uintwide_t_n_binary_ops_template<65536U, std::uint64_t, std::allocator<std::uint32_t>> test_uintwide_t_n_binary_ops_template_instance(count); // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+  #if defined(WIDE_INTEGER_NAMESPACE)
+  using allocator_type_type = std::allocator<WIDE_INTEGER_NAMESPACE::math::wide_integer::uint_defaultlimb_t>;
   #else
-  test_uintwide_t_n_binary_ops_template<65536U, std::uint32_t, std::allocator<std::uint32_t>> test_uintwide_t_n_binary_ops_template_instance(count); // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+  using allocator_type_type = std::allocator<::math::wide_integer::uint_defaultlimb_t>;
   #endif
+
+  std::cout << "running: test_uintwide_t_0065536_alloc" << std::endl;
+  test_uintwide_t_n_binary_ops_template<65536U, std::uint32_t, allocator_type_type> test_uintwide_t_n_binary_ops_template_instance(count); // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
   const auto result_is_ok =
     test_uintwide_t_n_binary_ops_template_instance.do_test(test_uintwide_t_n_binary_ops_rounds);
   return result_is_ok;

--- a/test/test_uintwide_t_float_convert.cpp
+++ b/test/test_uintwide_t_float_convert.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-//  Copyright Christopher Kormanyos 2021 - 2025.
+//  Copyright Christopher Kormanyos 2021 - 2026.
 //  Distributed under the Boost Software License,
 //  Version 1.0. (See accompanying file LICENSE_1_0.txt
 //  or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -217,10 +217,10 @@ auto ::math::wide_integer::test_uintwide_t_float_convert() -> bool
   using boost_uint_type = boost::multiprecision::number<boost_uint_backend_type, boost::multiprecision::et_on>;
   using boost_sint_type = boost::multiprecision::number<boost_sint_backend_type, boost::multiprecision::et_on>;
 
-  #if defined(WIDE_INTEGER_HAS_LIMB_TYPE_UINT64)
-  using local_limb_type = std::uint64_t;
+  #if defined(WIDE_INTEGER_NAMESPACE)
+  using local_limb_type = WIDE_INTEGER_NAMESPACE::math::wide_integer::uint_defaultlimb_t;
   #else
-  using local_limb_type = std::uint32_t;
+  using local_limb_type = ::math::wide_integer::uint_defaultlimb_t;
   #endif
 
   #if defined(WIDE_INTEGER_NAMESPACE)

--- a/test/test_uintwide_t_int_convert.cpp
+++ b/test/test_uintwide_t_int_convert.cpp
@@ -1,5 +1,5 @@
 ﻿///////////////////////////////////////////////////////////////////////////////
-//  Copyright Christopher Kormanyos 2021 - 2025.
+//  Copyright Christopher Kormanyos 2021 - 2026.
 //  Distributed under the Boost Software License,
 //  Version 1.0. (See accompanying file LICENSE_1_0.txt
 //  or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -173,10 +173,10 @@ auto ::math::wide_integer::test_uintwide_t_int_convert() -> bool
 
   using boost_sint_type = boost::multiprecision::number<boost_sint_backend_type, boost::multiprecision::et_on>;
 
-  #if defined(WIDE_INTEGER_HAS_LIMB_TYPE_UINT64)
-  using local_limb_type = std::uint64_t;
+  #if defined(WIDE_INTEGER_NAMESPACE)
+  using local_limb_type = WIDE_INTEGER_NAMESPACE::math::wide_integer::uint_defaultlimb_t;
   #else
-  using local_limb_type = std::uint32_t;
+  using local_limb_type = ::math::wide_integer::uint_defaultlimb_t;
   #endif
 
   #if defined(WIDE_INTEGER_NAMESPACE)

--- a/test/test_uintwide_t_n_binary_ops_mul_n_by_m_template.h
+++ b/test/test_uintwide_t_n_binary_ops_mul_n_by_m_template.h
@@ -16,15 +16,11 @@
   #if defined(WIDE_INTEGER_NAMESPACE)
   template<const WIDE_INTEGER_NAMESPACE::math::wide_integer::size_t MyDigits2A,
            const WIDE_INTEGER_NAMESPACE::math::wide_integer::size_t MyDigits2B,
-           typename MyLimbType = std::uint32_t>
+           typename MyLimbType = WIDE_INTEGER_NAMESPACE::math::wide_integer::uint_defaultlimb_t>
   #else
   template<const ::math::wide_integer::size_t MyDigits2A,
            const ::math::wide_integer::size_t MyDigits2B,
-           #if defined(WIDE_INTEGER_HAS_LIMB_TYPE_UINT64)
-           typename MyLimbType = std::uint64_t>
-           #else
-           typename MyLimbType = std::uint32_t>
-           #endif
+           typename MyLimbType = ::math::wide_integer::uint_defaultlimb_t>
   #endif
   class test_uintwide_t_n_binary_ops_mul_n_by_m_template : public test_uintwide_t_n_binary_ops_base // NOLINT(cppcoreguidelines-special-member-functions,hicpp-special-member-functions)
   {

--- a/test/test_uintwide_t_n_binary_ops_template.h
+++ b/test/test_uintwide_t_n_binary_ops_template.h
@@ -19,15 +19,11 @@
 
   #if defined(WIDE_INTEGER_NAMESPACE)
   template<const WIDE_INTEGER_NAMESPACE::math::wide_integer::size_t MyDigits2,
-           typename MyLimbType = std::uint32_t,
+           typename MyLimbType = WIDE_INTEGER_NAMESPACE::math::wide_integer::uint_defaultlimb_t,
            typename AllocatorType = void>
   #else
   template<const ::math::wide_integer::size_t MyDigits2,
-           #if defined(WIDE_INTEGER_HAS_LIMB_TYPE_UINT64)
-           typename MyLimbType = std::uint64_t,
-           #else
-           typename MyLimbType = std::uint32_t,
-           #endif
+           typename MyLimbType = ::math::wide_integer::uint_defaultlimb_t,
            typename AllocatorType = void>
   #endif
   class test_uintwide_t_n_binary_ops_template : public test_uintwide_t_n_binary_ops_base // NOLINT(cppcoreguidelines-special-member-functions,hicpp-special-member-functions)


### PR DESCRIPTION
Make consistent use of `uint_defaultlimb_t` and set 64-bit as default when `WIDE_INTEGER_HAS_LIMB_TYPE_UINT64` is set.