### PR TITLE
Move cmake_minimum_required() before project() call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-project(wide-integer)
-
 cmake_minimum_required(VERSION 3.16.3)
+
+project(wide-integer)
 
 if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
   set(WIDE_INTEGER_MASTER_PROJECT ON)


### PR DESCRIPTION
According to the CMake documentation (https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html), cmake_minimum_required() must be the first command in the
  top-level CMakeLists.txt, before the project() call. This is required because project() may implicitly set policies that depend on the minimum required version.

  Currently, the order is reversed, which causes the following dev warning when configuring the project:

  ```
CMake Warning (dev) at CMakeLists.txt:1 (project):
    cmake_minimum_required() should be called prior to this top-level project()
    call.  Please see the cmake-commands(7) manual for usage documentation of
    both commands.
```

  This PR simply swaps the two lines to fix the warning.